### PR TITLE
Fix: rednet library

### DIFF
--- a/data/computercraft/lua/rom/apis/rednet.lua
+++ b/data/computercraft/lua/rom/apis/rednet.lua
@@ -2,6 +2,8 @@
 
 local expect = require("cc.expect").expect
 local peripheral = require("peripheral")
+local rc = require("rc")
+local thread = require("rc.thread")
 
 local rednet = {
   CHANNEL_BROADCAST = 65535,
@@ -12,7 +14,7 @@ local rednet = {
 local opened = {}
 function rednet.open(modem)
   expect(1, modem, "string")
-  peripheral.call(modem, "open", os.computerID())
+  peripheral.call(modem, "open", rc.computerID())
   peripheral.call(modem, "open", rednet.CHANNEL_BROADCAST)
   opened[modem] = true
 end
@@ -22,7 +24,7 @@ local function call(method, modem, erase, passids, ...)
   if modem then
     if erase then opened[modem] = false end
     if passids then
-      ret = ret or peripheral.call(modem, method, os.computerID(), ...)
+      ret = ret or peripheral.call(modem, method, rc.computerID(), ...)
       ret = ret or peripheral.call(modem, method, rednet.CHANNEL_BROADCAST, ...)
     else
       ret = peripheral.call(modem, method, ...)
@@ -30,7 +32,7 @@ local function call(method, modem, erase, passids, ...)
 
   else
     for k in pairs(opened) do
-      ret = ret or call(k, method, erase, passids, ...)
+      ret = ret or call(method, k, erase, passids, ...)
     end
   end
   return ret
@@ -46,19 +48,22 @@ function rednet.isOpen(modem)
   return call("isOpen", modem, false, true)
 end
 
+---Composes the rednet message, to match the layout in the receive end.
+---Else, the rednet will not recognise the message as it's own.
+---@param to number The recipient or the port
+---@param message any The actual message, whichever it is.
+---@param protocol? string Optional protocol for filtering
+local function compose(to, message, protocol)
+  return { "rednet_message", to, message, protocol }
+end
+
 function rednet.send(to, message, protocol)
   expect(1, to, "number")
   expect(2, message, "string", "table", "number", "boolean")
   expect(3, protocol, "string", "nil")
 
-  if type(message) == "table" then
-    if protocol then table.insert(message, 1, protocol) end
-    table.insert(message, 1, "rednet_message")
-  else
-    message = {"rednet_message", to, message, protocol}
-  end
   call("transmit", nil, false, false, rednet.CHANNEL_BROADCAST,
-    os.computerID(), message)
+    rc.computerID(), compose(to, message, protocol))
   return rednet.isOpen()
 end
 
@@ -66,20 +71,20 @@ function rednet.broadcast(message, protocol)
   expect(1, message, "string", "table", "number", "boolean")
   expect(2, protocol, "string", "nil")
   call("transmit", nil, false, false, rednet.CHANNEL_BROADCAST,
-    rednet.CHANNEL_BROADCAST, message)
+    rednet.CHANNEL_BROADCAST, compose(rednet.CHANNEL_BROADCAST, message, protocol))
 end
 
 function rednet.receive(protocol, timeout)
   expect(1, protocol, "string", "nil")
-  timeout = expect(2, timeout, "number", "nil") or math.huge
+  timeout = expect(2, timeout, "number", "nil")
 
   local timer
   if timeout then
-    timer = os.startTimer(timer)
+    timer = rc.startTimer(timeout)
   end
 
   while true do
-    local event = table.pack(os.pullEvent())
+    local event = table.pack(rc.pullEvent())
     if event[1] == "timer" and event[2] == timer then return end
     if event[1] == "rednet_message" and (event[4] == protocol or
         not protocol) then
@@ -97,17 +102,24 @@ function rednet.run()
   running = true
 
   while true do
-    local event = table.pack(os.pullEvent())
+    local event = table.pack(rc.pullEvent())
+
     if event[1] == "modem_message" then
       local message = event[5]
       if type(message) == "table" then
-        if message[1] == "rednet_message" and (message[2] == os.computerID() or
-            message[2] == rednet.CHANNEL_BROADCAST) then
-          os.queueEvent("rednet_message", event[3], message[2], message[3])
+        local signature, recipient, payload, protocol = table.unpack(message)
+        if signature == "rednet_message" and (recipient == rc.computerID() or
+            recipient == rednet.CHANNEL_BROADCAST) then
+          rc.queueEvent("rednet_message", event[3], payload, protocol)
         end
       end
     end
   end
+end
+
+-- Start the event loop lazily
+if not running then
+  thread.spawn(rednet.run, "rednet_run")
 end
 
 return rednet


### PR DESCRIPTION
This PR should fix #9 , and other errors that appeared while fixing the rednet library. (At first seemed like just by replacing `os.<name>()`  method calls was enough, but other things need a fix).

Also I've noticed during the fix that the `rednet.run()` method was not running, so I've implemented a lazy thread launch of the pool (Feel free to modify that part if needed).

